### PR TITLE
Write to the css file alongside the scss file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-sass-processor-dart-sass"
-version = "0.0.1"
+version = "0.1.0"
 authors = [
   { name="Greg Kempe", email="greg@laws.africa" },
 ]

--- a/sass.py
+++ b/sass.py
@@ -1,4 +1,5 @@
 import subprocess
+from os.path import splitext
 from tempfile import NamedTemporaryFile
 
 
@@ -12,7 +13,8 @@ class DartSass:
         includes = [['-I', x] for x in include_paths]
         includes = [p for pp in includes for p in pp]
 
-        with NamedTemporaryFile() as outf:
+        outfname = splitext(filename)[0] + '.css'
+        with open(outfname, 'w+') as outf:
             cmd = self.sass_command + [
                 filename + ":" + outf.name,
                 *includes,


### PR DESCRIPTION
This ensures that the .map file has the correct relative paths, which means that caching is used correctly in development.

Without this django-sass-processor can't validate the source map and so always recompiles unchanged sass files during development.